### PR TITLE
Adding decoration field

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,21 @@ void onPhoneNumberChange(String number, String internationalizedPhoneNumber, Str
      ),
  );
 
+// Widget with decoration
+// Using decoration overwrites other styles such as hintStyle, hintText, etc.
+
+@override
+ Widget build(BuildContext context) => Scaffold(
+     body: Center(
+       child: InternationalPhoneInput(
+          decoration: InputDecoration.collapsed(hintText: '(416) 123-4567'),
+          onPhoneNumberChange: onPhoneNumberChange, 
+          initialPhoneNumber: phoneNumber,
+          initialSelection: phoneIsoCode,
+          enabledCountries: ['+233', '+1']
+       ),
+     ),
+ );
 
 ```
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -61,7 +61,15 @@ class _MyHomePageState extends State<MyHomePage> {
               enabledCountries: ['+233', '+1'],
               labelText: "Phone Number",
             ),
-            SizedBox(height: 50),
+            SizedBox(height: 20),
+            InternationalPhoneInput(
+              decoration: InputDecoration.collapsed(hintText: '(123) 123-1234'),
+              onPhoneNumberChange: onPhoneNumberChange,
+              initialPhoneNumber: phoneNumber,
+              initialSelection: phoneIsoCode,
+              enabledCountries: ['+233', '+1'],
+            ),
+            SizedBox(height: 20),
             Container(
               width: double.infinity,
               height: 1,

--- a/lib/src/international_phone_input.dart
+++ b/lib/src/international_phone_input.dart
@@ -22,6 +22,7 @@ class InternationalPhoneInput extends StatefulWidget {
   final TextStyle labelStyle;
   final int errorMaxLines;
   final List<String> enabledCountries;
+  final InputDecoration decoration;
 
   InternationalPhoneInput(
       {this.onPhoneNumberChange,
@@ -34,7 +35,8 @@ class InternationalPhoneInput extends StatefulWidget {
       this.hintStyle,
       this.labelStyle,
       this.enabledCountries = const [],
-      this.errorMaxLines});
+      this.errorMaxLines,
+      this.decoration});
 
   static Future<String> internationalizeNumber(String number, String iso) {
     return PhoneService.getNormalizedPhoneNumber(number, iso);
@@ -61,6 +63,8 @@ class _InternationalPhoneInputState extends State<InternationalPhoneInput> {
 
   bool hasError = false;
 
+  InputDecoration decoration;
+
   _InternationalPhoneInputState();
 
   final phoneTextController = TextEditingController();
@@ -74,6 +78,7 @@ class _InternationalPhoneInputState extends State<InternationalPhoneInput> {
     hintStyle = widget.hintStyle;
     labelStyle = widget.labelStyle;
     errorMaxLines = widget.errorMaxLines;
+    decoration = widget.decoration;
 
     phoneTextController.addListener(_validatePhoneNumber);
     phoneTextController.text = widget.initialPhoneNumber;
@@ -198,7 +203,7 @@ class _InternationalPhoneInputState extends State<InternationalPhoneInput> {
               child: TextField(
             keyboardType: TextInputType.phone,
             controller: phoneTextController,
-            decoration: InputDecoration(
+            decoration: decoration ?? InputDecoration(
               hintText: hintText,
               labelText: labelText,
               errorText: hasError ? errorText : null,


### PR DESCRIPTION
I added a `decoration` field in order to make changes to the input field. However, using `decoration` ignores other fields such as `hintText` or `hintStyle`.

I also updated the `README.md` and the `main.dart` in the examples folder for the example usage.