### PR TITLE
Fixed selectedItem.code null exception when presetting initial data

### DIFF
--- a/lib/src/international_phone_input.dart
+++ b/lib/src/international_phone_input.dart
@@ -96,7 +96,6 @@ class _InternationalPhoneInputState extends State<InternationalPhoneInput> {
     dropdownIcon = widget.dropdownIcon;
 
     phoneTextController.addListener(_validatePhoneNumber);
-    phoneTextController.text = widget.initialPhoneNumber;
 
     _fetchCountryData().then((list) {
       Country preSelectedItem;
@@ -116,6 +115,8 @@ class _InternationalPhoneInputState extends State<InternationalPhoneInput> {
         itemList = list;
         selectedItem = preSelectedItem;
       });
+
+      phoneTextController.text = widget.initialPhoneNumber;
     });
 
     super.initState();


### PR DESCRIPTION
When setting initialSelection and initialPhoneNumber, selectedItem equals null, but the __validatePhoneNumber method is being triggered by some lines above. It is looking up the code field on the nonexistent selectedItem, and that gives me this exception. Moving a text setting line right after selection setting lines fixes the issue.
![image](https://user-images.githubusercontent.com/25486499/83285012-37446280-a1e6-11ea-9a4d-fe16b9682a5f.png)
